### PR TITLE
Duplicate func fix -  add id

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,12 @@ If you are not using npm or Bower, then grab either the [minified](https://raw.g
 #### **.on()**
 
 ```javascript
-Bullet.on('someMessageName', callback);
+Bullet.on('someMessageName', callback[, once, id]);
 ```
 
 Register a callback function to get called whenever the specified message is triggered.
-
+If the optional once flag is set to true then the function is the same as calling `Bullet.once(...)`.
+The optional id parameter can be used when the same callback function is used by multiple modules
 
 **Example usage:**
 
@@ -73,6 +74,16 @@ Bullet.on('hello', helloCallback);
 
 Bullet.trigger('hello');
 
+// Register the 'helloCallback' function again, but with an id
+
+Bullet.on("hello", helloCallback, false, "myId");
+
+// ...
+
+// Triggering the 'hello' message will now call helloCallback twice, for without the id and with the id (which separates it from the first)
+
+Bullet.trigger('hello'); 
+
 ```
 
 
@@ -82,10 +93,10 @@ Bullet.trigger('hello');
 #### **.off()**
 
 ```javascript
-Bullet.off('someMessageName'[, callback]);
+Bullet.off('someMessageName'[, callback, id]);
 ```
 
-Remove either all callback functions or a specific callback function registered against the specified message.
+Remove either all callback functions or a specific callback function (with optional id) registered against the specified message.
 
 ```javascript
 Bullet.off();
@@ -146,22 +157,32 @@ function anotherCallback () {
 
 Bullet.on('hello', helloCallback);
 Bullet.on('hello', anotherCallback);
+Bullet.on('hello', anotherCallback, false, "myId");
 
 
 // Somewhere later in the application...
 
 
-// Trigger the 'hello' message – Bullet will call both the 'helloCallback' and 'anotherCallback' functions:
+// Trigger the 'hello' message – Bullet will call both the 'helloCallback' and 'anotherCallback' (calling it twice because of the id) functions:
 
 Bullet.trigger('hello');
 
 
-// Remove only the 'anotherCallback' function associated with the 'hello' message:
+// Remove only the 'anotherCallback' function associated with the 'hello' message, which doesn't use an id:
 
 Bullet.off('hello', anotherCallback);
 
 
-// Trigger the 'hello' message again – Bullet will only call the 'helloCallback' function:
+// Trigger the 'hello' message again – Bullet will call both the 'helloCallback' and 'anotherCallback' (this time only once because of the id case) function:
+
+Bullet.trigger('hello');
+
+// Remove only the 'anotherCallback' function associated with the 'hello' message, which is associated with the 'myId' id:
+
+Bullet.off('hello', anotherCallback, "myId");
+
+
+// Trigger the 'hello' message again – Bullet will call only the 'helloCallback' function:
 
 Bullet.trigger('hello');
 
@@ -221,7 +242,7 @@ Bullet.trigger('goodbye');
 #### **.once()**
 
 ```javascript
-Bullet.once('someMessageName', callback);
+Bullet.once('someMessageName', callback[, id]);
 ```
 
 This function behaves in the same way as the the `on` function, except that – once registered – the callback function will only be called a single time when the specified message is triggered.
@@ -331,10 +352,11 @@ Bullet.trigger('hello', customData);
 #### **.replaceCallback()**
 
 ```javascript
-Bullet.replaceCallback('someMessageName', oldCallback, newCallback[, once]);
+Bullet.replaceCallback('someMessageName', oldCallback, newCallback[, once, oldCallbackId, newCallbackId]);
 ```
 
 Replace a single mapped callback for the specified event name with a new callback, optionally setting the 'once' parameter.
+You can also optionally use the function id's that are used when adding event listeners, both for finding the old callback function with the id and with setting the new callback function id. 
 
 
 **Example usage:**
@@ -374,10 +396,10 @@ Bullet.replaceCallback(Bullet.events.hello, helloCallback, someOtherCallback, tr
 #### **.replaceAllCallbacks()**
 
 ```javascript
-Bullet.replaceAllCallbacks('someMessageName', newCallback[, once]);
+Bullet.replaceAllCallbacks('someMessageName', newCallback[, once, id]);
 ```
 
-Replace all of the specified event name’s mapped callbacks with the specified callback, optionally setting the 'once' parameter.
+Replace all of the specified event name’s mapped callbacks with the specified callback, optionally setting the 'once' parameter and the 'id' parameter for the new callback funciton id.
 
 
 **Example usage:**

--- a/src/bullet.js
+++ b/src/bullet.js
@@ -120,16 +120,25 @@
 
             return clonedMappings;
         };
+        
+        
+        // Simple constructor for the function id
+        _self._getFunctionId = function (fn, id) {
+            if (id === undefined) {
+                return fn.toString();
+            }
+            return id + "-" + fn.toString(); 
+        };
 
 
         // ------------------------------------------------------------------------------------------
         // -- Public methods
         // ------------------------------------------------------------------------------------------
-        _self.on = function (eventName, fn, once)
+        _self.on = function (eventName, fn, once, id)
         {
-            if (arguments.length < 2 || arguments.length > 3)
+            if (arguments.length < 2 || arguments.length > 4)
             {
-                throw new ParamCountError('on', 'Expected between 2 and 3 parameters', arguments.length);
+                throw new ParamCountError('on', 'Expected between 2 and 4 parameters', arguments.length);
             }
 
             if (typeof eventName !== 'string')
@@ -154,8 +163,13 @@
             {
                 throw new ParamTypeError('on', 'once', once, 'boolean');
             }
+            
+            if (typeof id !== 'undefined' && typeof id !== 'string')
+            {
+                throw new ParamTypeError('on', 'id', id, 'string');
+            }
 
-            var fnString = fn.toString();
+            var fnString = _self._getFunctionId(fn, id);
 
             // If the named event object already exists in the dictionary...
             if (typeof _mappings[eventName] !== 'undefined')
@@ -188,11 +202,11 @@
             }
         };
 
-        _self.once = function (eventName, fn)
+        _self.once = function (eventName, fn, id)
         {
-            if (arguments.length !== 2)
+            if (arguments.length < 2 || arguments.length > 3)
             {
-                throw new ParamCountError('once', 'Expected 2 parameters', arguments.length);
+                throw new ParamCountError('once', 'Expected between 2 and 3 parameters', arguments.length);
             }
             else if (typeof eventName !== 'string')
             {
@@ -211,11 +225,16 @@
             {
                 throw new ParamTypeError('once', 'callback', fn, 'function');
             }
+            
+            if (typeof id !== 'undefined' && typeof id !== 'string')
+            {
+                throw new ParamTypeError('once', 'id', id, 'string');
+            }
 
-            _self.on(eventName, fn, true);
+            _self.on(eventName, fn, true, id);
         };
 
-        _self.off = function (eventName, fn)
+        _self.off = function (eventName, fn, id)
         {
             if (arguments.length === 0)
             {
@@ -241,11 +260,16 @@
                 // There is no mapping to remove, so return silently.
                 return;
             }
+            
+            if (typeof id !== 'undefined' && typeof id !== 'string')
+            {
+                throw new ParamTypeError('off', 'id', id, 'string');
+            }
 
             // Remove just the function, if passed as a parameter and in the dictionary.
             if (typeof fn === 'function')
             {
-                var fnString = fn.toString(),
+                var fnString = fnString = _self._getFunctionId(fn, id),
                     fnToRemove = _mappings[eventName].callbacks[fnString];
 
                 if (typeof fnToRemove !== 'undefined')
@@ -276,7 +300,7 @@
         };
 
         // Replace a single mapped callback for the specified event name with a new callback.
-        _self.replaceCallback = function (eventName, oldFn, newFn, once) {
+        _self.replaceCallback = function (eventName, oldFn, newFn, once, id) {
 
             if (typeof eventName !== 'string')
             {
@@ -310,12 +334,17 @@
                 throw new ParamTypeError('replaceCallback', 'once', once, 'boolean');
             }
             
-            _self.off(eventName, oldFn);
-            _self.on(eventName, newFn, once);
+            if (typeof id !== 'undefined' && typeof id !== 'string')
+            {
+                throw new ParamTypeError('replaceCallback', 'id', id, 'string');
+            }
+            
+            _self.off(eventName, oldFn, id);
+            _self.on(eventName, newFn, once, id);
         };
 
         // Replace all of the specified event name’s mapped callbacks with the specified callback.
-        _self.replaceAllCallbacks = function (eventName, newFn, once) {
+        _self.replaceAllCallbacks = function (eventName, newFn, once, id) {
 
             if (typeof eventName !== 'string')
             {
@@ -344,8 +373,13 @@
                 throw new ParamTypeError('replace', 'once', once, 'boolean');
             }
             
+            if (typeof id !== 'undefined' && typeof id !== 'string')
+            {
+                throw new ParamTypeError('replace', 'id', id, 'string');
+            }
+            
             _self.off(eventName);
-            _self.on(eventName, newFn, once);
+            _self.on(eventName, newFn, once, id);
         };
 
         _self.trigger = function (eventName, data)

--- a/src/bullet.js
+++ b/src/bullet.js
@@ -300,7 +300,7 @@
         };
 
         // Replace a single mapped callback for the specified event name with a new callback.
-        _self.replaceCallback = function (eventName, oldFn, newFn, once, id) {
+        _self.replaceCallback = function (eventName, oldFn, newFn, once, oldFnId, newFnId) {
 
             if (typeof eventName !== 'string')
             {
@@ -334,13 +334,18 @@
                 throw new ParamTypeError('replaceCallback', 'once', once, 'boolean');
             }
             
-            if (typeof id !== 'undefined' && typeof id !== 'string')
+            if (typeof oldFnId !== 'undefined' && typeof oldFnId !== 'string')
             {
-                throw new ParamTypeError('replaceCallback', 'id', id, 'string');
+                throw new ParamTypeError('replaceCallback', 'id', oldFnId, 'string');
             }
             
-            _self.off(eventName, oldFn, id);
-            _self.on(eventName, newFn, once, id);
+            if (typeof newFnId !== 'undefined' && typeof newFnId !== 'string')
+            {
+                throw new ParamTypeError('replaceCallback', 'id', newFnId, 'string');
+            }
+            
+            _self.off(eventName, oldFn, oldFnId);
+            _self.on(eventName, newFn, once, newFnId);
         };
 
         // Replace all of the specified event name’s mapped callbacks with the specified callback.

--- a/test/spec/bullet-spec.js
+++ b/test/spec/bullet-spec.js
@@ -162,6 +162,30 @@ describe('Bullet', function () {
 
                 expect(mappings[this.testEventName].callbacks[testCallbackString]).to.be.an('object');
             });
+            
+            it('should create different mappings for differnt ids when the same function is used', function () {
+                
+                var id1 = "id1";
+                var id2 = "id2";
+                var mappings = this.bullet._getMappings();
+
+                expect(mappings[this.testEventName]).to.be.an('undefined');
+
+                // Add an event.
+                this.bullet.on(this.testEventName, this.testCallback, false, id1);
+                this.bullet.on(this.testEventName, this.testCallback, false, id2);
+                
+                // Get the updated events map.
+                mappings = this.bullet._getMappings();
+
+                var testCallbackString1 = this.bullet._getFunctionId(this.testCallback, id1);
+                var testCallbackString2 = this.bullet._getFunctionId(this.testCallback, id2);
+                
+                expect(testCallbackString1).to.not.be.equal(testCallbackString2);
+
+                expect(mappings[this.testEventName].callbacks[testCallbackString1]).to.be.an('object');
+                expect(mappings[this.testEventName].callbacks[testCallbackString2]).to.be.an('object');
+            });
 
             it('should throw a ParamTypeError if the event name param is not a string', function () {
 
@@ -200,8 +224,8 @@ describe('Bullet', function () {
                 // The map should still be empty
                 expect(this.bullet._getMappings()).to.deep.equal({});
             });
-
-            it('should throw a ParamTypeError if the callback parameter is not a function', function () {
+            
+             it('should throw a ParamTypeError if the id parameter is not a string', function () {
 
                 var self = this;
 
@@ -258,7 +282,7 @@ describe('Bullet', function () {
                 expect(this.bullet._getMappings()).to.deep.equal({});
             });
 
-            it('should throw a ParamCountError if more than three parameters are passed', function () {
+            it('should throw a ParamCountError if more than four parameters are passed', function () {
 
                 var self = this;
 
@@ -268,7 +292,7 @@ describe('Bullet', function () {
                 function callOn () {
 
                     // Attempt to map an event with more than three params.
-                    self.bullet.on(self.testEventName, self.testCallback, true, 123);
+                    self.bullet.on(self.testEventName, self.testCallback, true, 123, "test");
                 }
 
                 expect(callOn).to.throw(this.bullet._errors.ParamCountError);


### PR DESCRIPTION
I've had issues with my classes where func.toString() is giving "function () { [native code] }", so if I listen to an event name more than once from different classes, they are overwriting themselves in the mappings and only one function (the last to be registered) is being called. I've proposed using an id that I can pass in (a class name for example) so to separate out the functions on event listeners.

Example the two callback functions, despite having different internals and producing the same string on func.toString()

``` javascript
var myClass = function () {
    Bullet.on("eventname", this._callback.bind(this));
};

myClass.prototype._callback = function () {
    // ... Do something
};


var mySecondClass = function () {
    Bullet.on("eventname", this._callback.bind(this));
};

mySecondClass.prototype._callback = function () {
    // ... Do something else
};
```

My proposal usage:

``` javascript
var myClass = function () {
    Bullet.on("eventname", this._callback.bind(this), false, "myClass");
};

myClass.prototype._callback = function () {
    // ... Do something
};


var mySecondClass = function () {
    Bullet.on("eventname", this._callback.bind(this), false, "mySecondClass");
};

mySecondClass.prototype._callback = function () {
    // ... Do something else
};
```

Please feel free to comment on this, I've also tried to update the tests and follow your writing style.
